### PR TITLE
Remove import from concatenated solidity output

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const SolidityParser = require("solidity-parser");
 
 const PRAGAMA_SOLIDITY_VERSION_REGEX = /^\s*pragma\ssolidity\s+(.*?)\s*;/;
 const SUPPORTED_VERSION_DECLARATION_REGEX = /^\^?\d+(\.\d+){1,2}$/;
+const IMPORT_SOLIDITY_REGEX = /^.*import.*$/mg;
 
 function unique(array) {
   return [...new Set(array)];
@@ -102,7 +103,7 @@ async function printFileWithoutPragma(filePath) {
   const output = resolved.fileContents.replace(
     PRAGAMA_SOLIDITY_VERSION_REGEX,
     ""
-  );
+  ).replace(IMPORT_SOLIDITY_REGEX,"");
 
   console.log(output.trim());
 }


### PR DESCRIPTION
This is a simple addition to your preprocessor or flattener.
I removed the imports so that they wouldn't create errors during compilation. 

From after this PR. I think we will diverge in ideas, I don't think it's a good idea to give the option of adding more than one Parent smart contract, or at least I  don't know any use case like this. 

What I mean is, for example, it would make sense to create different output streams for different parent or main smart-contracts but there would be no use case for contacting all smart contracts together in the same output stream.