### PR TITLE
add support for finding root based on file truffle.js or truffle-conf…

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,20 +207,19 @@ async function printContactenation(files) {
 }
 
 async function getTruffleRoot() {
+  try {
+      const truffleConfiPath = await findUp("truffle.js");
+      return getDirPath(truffleConfiPath);
+  } catch (error) {
     try {
-        const truffleConfiPath = await findUp("truffle.js");
-        return getDirPath(truffleConfiPath);
-    } catch (error) {
-        try {
-            const truffleConfiPath = await findUp("truffle-config.js");
-            return getDirPath(truffleConfiPath);
-        }
-        catch (error) {
-            throw new Error(
-                "Truffle Flattener must be run inside a Truffle project: truffle.js not found"
-            );
-        }
+      const truffleConfiPath = await findUp("truffle-config.js");
     }
+    catch (error) {
+      throw new Error(
+        "Truffle Flattener must be run inside a Truffle project: truffle.js not found"
+      );
+    }
+  }
 }
 
 function getFilePathsFromTruffleRoot(filePaths, truffleRoot) {

--- a/index.js
+++ b/index.js
@@ -207,14 +207,20 @@ async function printContactenation(files) {
 }
 
 async function getTruffleRoot() {
-  try {
-    const truffleConfiPath = await findUp("truffle.js");
-    return getDirPath(truffleConfiPath);
-  } catch (error) {
-    throw new Error(
-      "Truffle Flattener must be run inside a Truffle project: truffle.js not found"
-    );
-  }
+    try {
+        const truffleConfiPath = await findUp("truffle.js");
+        return getDirPath(truffleConfiPath);
+    } catch (error) {
+        try {
+            const truffleConfiPath = await findUp("truffle-config.js");
+            return getDirPath(truffleConfiPath);
+        }
+        catch (error) {
+            throw new Error(
+                "Truffle Flattener must be run inside a Truffle project: truffle.js not found"
+            );
+        }
+    }
 }
 
 function getFilePathsFromTruffleRoot(filePaths, truffleRoot) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-flattener",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Truffle Flattener concats solidity files developed under Truffle with all of their dependencies",
   "bin": {
     "truffle-flattener": "index.js"


### PR DESCRIPTION
The configuration file for Truffle can be called truffle.js or truffle-config.js (https://github.com/trufflesuite/truffle-config/blob/861f3100a2dbe23f3183cfa54e56d18ff7450acb/index.js#L10-L11).

truffle-flattener assumes it's at truffle.js, with this PR it now support both files. Version bumped to 1.2.1